### PR TITLE
add relative to bracket mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,10 @@
           "description": "Wether to display the current indent depth on the statusbar"
         },
         "indenticator.showHover": {
-          "type": ["boolean", "number"],
+          "type": [
+            "boolean",
+            "number"
+          ],
           "default": false,
           "description": "Wether to display the hover near the indent line, or minimum number of lines in current indent block to activate the hover."
         },
@@ -116,13 +119,17 @@
           "description": "Block placeholder to be written between peeked lines"
         },
         "indenticator.languageSpecific": {
-          "type": ["object"],
+          "type": [
+            "object"
+          ],
           "default": {},
           "description": "A construct with language identifiers as properties containing a subset of indenticator options to be applied to that language",
           "additionalProperties": false,
           "patternProperties": {
             "^\\[.+\\]$": {
-              "type": ["object"],
+              "type": [
+                "object"
+              ],
               "description": "Language Specific config",
               "additionalProperties": false,
               "properties": {
@@ -152,7 +159,10 @@
                   "description": "Wether to display the current indent depth on the statusbar"
                 },
                 "indenticator.showHover": {
-                  "type": ["boolean", "number"],
+                  "type": [
+                    "boolean",
+                    "number"
+                  ],
                   "default": false,
                   "description": "Wether to display the hover near the indent line, or minimum number of lines in current indent block to activate the hover."
                 },
@@ -175,6 +185,11 @@
                   "type": "string",
                   "default": "...",
                   "description": "Block placeholder to be written between peeked lines."
+                },
+                "indenticator.columnPriorityMode": {
+                  "type": "boolean",
+                  "default": true,
+                  "description": "Column position is prior to position of relative to bracket."
                 }
               }
             }

--- a/package.json
+++ b/package.json
@@ -91,10 +91,7 @@
           "description": "Wether to display the current indent depth on the statusbar"
         },
         "indenticator.showHover": {
-          "type": [
-            "boolean",
-            "number"
-          ],
+          "type": ["boolean", "number"],
           "default": false,
           "description": "Wether to display the hover near the indent line, or minimum number of lines in current indent block to activate the hover."
         },
@@ -119,17 +116,13 @@
           "description": "Block placeholder to be written between peeked lines"
         },
         "indenticator.languageSpecific": {
-          "type": [
-            "object"
-          ],
+          "type": ["object"],
           "default": {},
           "description": "A construct with language identifiers as properties containing a subset of indenticator options to be applied to that language",
           "additionalProperties": false,
           "patternProperties": {
             "^\\[.+\\]$": {
-              "type": [
-                "object"
-              ],
+              "type": ["object"],
               "description": "Language Specific config",
               "additionalProperties": false,
               "properties": {
@@ -159,10 +152,7 @@
                   "description": "Wether to display the current indent depth on the statusbar"
                 },
                 "indenticator.showHover": {
-                  "type": [
-                    "boolean",
-                    "number"
-                  ],
+                  "type": ["boolean", "number"],
                   "default": false,
                   "description": "Wether to display the hover near the indent line, or minimum number of lines in current indent block to activate the hover."
                 },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -328,13 +328,13 @@ export class IndentSpy {
                             tabSize: number) {
         if(selection.isSingleLine) {
             let line = document.lineAt(selection.start.line);
-            if (!this._columnPriority) {
-                return this._getIndentDepth(this._getIndentWithBracket(document, line,selection,tabSize), tabSize)+1;
+            if (this._columnPriority) {
+                return this._getIndentDepth(
+                    Math.min(selection.start.character,
+                             line.firstNonWhitespaceCharacterIndex),
+                    tabSize);
             }
-            return this._getIndentDepth(
-                Math.min(selection.start.character+1,
-                         line.firstNonWhitespaceCharacterIndex),
-                tabSize);
+            return this._getIndentDepth(this._getIndentWithBracket(document, line,selection,tabSize), tabSize)+1;
         }
         let selectedIndent = Number.MAX_VALUE;
         let targetCol;


### PR DESCRIPTION
Hi!
I add "relative to bracket mode" differ from previous you made.
This mode calculate guide line by previous or next bracket, not column position.

I think this suggesution is relative to #14.

Config property is columnPriorityMode.
default : true   ... this is same as you made.
             false   ...  This time suggestion.

I didn't implement auto yank from language configuration info such " { [("  .  This time  hard coding.
I checked Typescript, javascript , html.
But I didn't test with hover case.

I would like to you like this.

Thank you.
