### PR TITLE
[i18n] add Japanese translations

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,8 @@ export class IndentSpy {
                  statusTooltip: `current indent depth: {indent}`},
             de: {statusText: `Einzüge: {indent}`,
                  statusTooltip: `aktuelle Einzugtiefe: {indent}`},
+            ja: {statusText: `字下げ: {indent}`,
+                 statusTooltip: `現在のインデントの深さ: {indent}`},
             default: {statusText: `Indents: {indent}`,
                       statusTooltip: `current indent depth: {indent}`},
         };


### PR DESCRIPTION
This minor patch adds Japanese translations to your extension.

I really like this plugin and it helps me a lot, but it feels kinda out of place in my Japanese configured VS Code, so I looked at the source code to check if the strings are hardcoded to English or if the extension is translatable. So good job on not hardcoding the extension in English-only :+1: 

There are a lot of English-only extensions for VS Code unfortunately.